### PR TITLE
Add virtio driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,7 @@ include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-set(SOURCE_COMMON src/pci.c src/memory.c src/stats.c src/driver/device.c src/driver/ixgbe.c)
+set(SOURCE_COMMON src/pci.c src/memory.c src/stats.c src/driver/device.c src/driver/ixgbe.c src/driver/virtio.c)
 
 add_executable(ixy-pktgen src/app/ixy-pktgen.c ${SOURCE_COMMON})
 add_executable(ixy-fwd src/app/ixy-fwd.c ${SOURCE_COMMON})
-

--- a/README.md
+++ b/README.md
@@ -13,13 +13,14 @@ Low-level functions like handling DMA descriptors are rarely more than a single 
 
 A whole ixy app, including the whole driver, is only ~1000 lines of C code.
 Check out the `ixy-fwd` and `ixy-pktgen` example apps and look through the code.
-The code often references sections in the [Intel 82599 datasheet](https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/82599-10-gbe-controller-datasheet.pdf), so keep it open while reading the code.
+The code often references sections in the [Intel 82599 datasheet](https://www.intel.com/content/dam/www/public/us/en/documents/datasheets/82599-10-gbe-controller-datasheet.pdf) or the [VirtIO specification](http://docs.oasis-open.org/virtio/virtio/v1.0/virtio-v1.0.pdf), so keep them open while reading the code.
 You will be surprised how simple a full driver for a network card can be.
 
 
 
 # Features
 * Driver for Intel NICs in the `ixgbe` family, i.e., the 82599ES family (aka Intel X520)
+* Driver for paravirtualized virtio NICs
 * Less than 1000 lines of C code for a packet forwarder including the whole driver
 * No kernel modules needed
 * Simple API with memory management, similar to DPDK, easier to use than APIs based on a ring interface (e.g., netmap)
@@ -44,14 +45,14 @@ If you prefer to dive into the code: Start by reading the apps in [src/app](http
 **Your NIC has full DMA access to your memory. A misconfigured NIC will cause memory corruptions that might crash your server or even destroy your filesystem**. Do not run this on any systems that have anything remotely important on them if you want to modify the driver. Our version is also not necessarily safe and might be buggy. You have been warned.
 
 **Running ixy will unbind the driver of the given PCIe device without checking if it is in use.** This means the NIC will disappear from the system. Do not run this on NICs that you need.
-We currently don't check if the device is actually a supported NIC, trying to use another device will crash your system.
+We currently have a simple check if the device is actually a NIC, but trying to use another device could crash your system.
 
 1. Install the following dependencies
 	* gcc >= 4.8
 	* make
 	* cmake
 	
-	Run this Debian/Ubuntu to install them:
+	Run this on Debian/Ubuntu to install them:
 	
 	```
 	sudo apt-get install -y build-essential cmake
@@ -89,8 +90,8 @@ The list is in no particular order.
 
 ### Implement at least one other driver beside ixgbe
 
-To showcase how to make the framework more independent from the used hardware.
-Virtual NICs like VirtIO are a good candidate to build a simple VM-based environment.
+~~To showcase how to make the framework more independent from the used hardware.
+Virtual NICs like VirtIO are a good candidate to build a simple VM-based environment.~~
 
 NICs that rely too much on firmware (e.g., Intel XL710) are not fun, because you end up only talking to a firmware that does everything.
 The same is true for NICs like the ones by Mellanox that keep a lot of magic in kernel modules, even when being used by frameworks like DPDK.

--- a/src/app/ixy-pktgen.c
+++ b/src/app/ixy-pktgen.c
@@ -24,7 +24,7 @@ static struct mempool* init_mempool() {
 		buf->size = PKT_SIZE;
 		// TODO: initialize packet with something else here
 		for (int i = 0; i < PKT_SIZE; i++) {
-			buf->data[i] = 0xFF;
+			buf->data[i] = (uint8_t) (i % 256);
 		}
 		bufs[buf_id] = buf;
 	}

--- a/src/driver/device.c
+++ b/src/driver/device.c
@@ -1,10 +1,22 @@
 #include "device.h"
 #include "driver/ixgbe.h"
+#include "driver/virtio.h"
+#include "pci.h"
 
 struct ixy_device* ixy_init(const char* pci_addr, uint16_t rx_queues, uint16_t tx_queues) {
-	if (true /* Detection magic */) {
-		return ixgbe_init(pci_addr, rx_queues, tx_queues);
+	// Read PCI configuration space
+	int config = pci_open_resource(pci_addr, "config");
+	uint16_t vendor_id = read_io16(config, 0);
+	uint16_t device_id = read_io16(config, 2);
+	uint32_t class_id = read_io32(config, 8) >> 24;
+	close(config);
+	if (class_id != 2) {
+		error("Device %s is not a NIC", pci_addr);
+	}
+	if (vendor_id == 0x1af4 && device_id >= 0x1000) {
+		return virtio_init(pci_addr, rx_queues, tx_queues);
 	} else {
-		error("Unsupported device");
+		// Our best guess is to try ixgbe
+		return ixgbe_init(pci_addr, rx_queues, tx_queues);
 	}
 }

--- a/src/driver/device.h
+++ b/src/driver/device.h
@@ -61,16 +61,16 @@ static inline void ixy_set_promisc(struct ixy_device* dev, bool enabled) {
 	dev->set_promisc(dev, enabled);
 }
 
+static inline uint32_t get_link_speed(const struct ixy_device* dev) {
+	return dev->get_link_speed(dev);
+}
+
 // calls ixy_tx_batch until all packets are queued with busy waiting
 static void ixy_tx_batch_busy_wait(struct ixy_device* dev, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs) {
 	uint32_t num_sent = 0;
 	while ((num_sent += ixy_tx_batch(dev, 0, bufs + num_sent, num_bufs - num_sent)) != num_bufs) {
 		// busy wait
 	}
-}
-
-static inline uint32_t get_link_speed(const struct ixy_device* dev) {
-	return dev->get_link_speed(dev);
 }
 
 // getters/setters for PCIe memory mapped registers
@@ -117,4 +117,48 @@ static inline void wait_set_reg32(const uint8_t* addr, int reg, uint32_t mask) {
 	}
 }
 
-#endif //IXY_DEVICE_H
+// getters/setters for pci io port resources
+
+static inline void write_io32(int fd, uint32_t value, size_t offset) {
+	if (pwrite(fd, &value, sizeof(value), offset) != sizeof(value))
+		error("pwrite io resource");
+	__asm__ volatile("" : : : "memory");
+}
+
+static inline void write_io16(int fd, uint16_t value, size_t offset) {
+	if (pwrite(fd, &value, sizeof(value), offset) != sizeof(value))
+		error("pwrite io resource");
+	__asm__ volatile("" : : : "memory");
+}
+
+static inline void write_io8(int fd, uint8_t value, size_t offset) {
+	if (pwrite(fd, &value, sizeof(value), offset) != sizeof(value))
+		error("pwrite io resource");
+	__asm__ volatile("" : : : "memory");
+}
+
+static inline uint32_t read_io32(int fd, size_t offset) {
+	__asm__ volatile("" : : : "memory");
+	uint32_t temp;
+	if (pread(fd, &temp, sizeof(temp), offset) != sizeof(temp))
+		error("pread io resource");
+	return temp;
+}
+
+static inline uint16_t read_io16(int fd, size_t offset) {
+	__asm__ volatile("" : : : "memory");
+	uint16_t temp;
+	if (pread(fd, &temp, sizeof(temp), offset) != sizeof(temp))
+		error("pread io resource");
+	return temp;
+}
+
+static inline uint8_t read_io8(int fd, size_t offset) {
+	__asm__ volatile("" : : : "memory");
+	uint8_t temp;
+	if (pread(fd, &temp, sizeof(temp), offset) != sizeof(temp))
+		error("pread io resource");
+	return temp;
+}
+
+#endif // IXY_DEVICE_H

--- a/src/driver/virtio.c
+++ b/src/driver/virtio.c
@@ -1,0 +1,481 @@
+#include <emmintrin.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "driver/device.h"
+#include "log.h"
+#include "memory.h"
+#include "pci.h"
+#include "virtio.h"
+#include "virtio_type.h"
+
+static const char* driver_name = "ixy-virtio";
+
+static inline void virtio_legacy_notify_queue(struct virtio_device* dev, uint16_t idx) {
+	write_io16(dev->fd, idx, VIRTIO_PCI_QUEUE_NOTIFY);
+}
+
+static uint8_t virtio_legacy_get_status(struct virtio_device* dev) {
+	return read_io8(dev->fd, VIRTIO_PCI_STATUS);
+}
+
+static void virtio_legacy_check_status(struct virtio_device* dev) {
+	if (read_io8(dev->fd, VIRTIO_PCI_STATUS) == VIRTIO_CONFIG_STATUS_FAILED) {
+		error("Device signaled unrecoverable error");
+	}
+}
+
+static inline size_t virtio_legacy_vring_size(unsigned int num, unsigned long align) {
+	size_t size;
+
+	size = num * sizeof(struct vring_desc);
+	size += sizeof(struct vring_avail) + (num * sizeof(uint16_t));
+	size = RTE_ALIGN_CEIL(size, align);
+	size += sizeof(struct vring_used) + (num * sizeof(struct vring_used_elem));
+	return size;
+}
+
+static inline void virtio_legacy_vring_init(struct vring* vr, unsigned int num, uint8_t* p, unsigned long align) {
+	vr->num = num;
+	vr->desc = (struct vring_desc*)p;
+	vr->avail = (struct vring_avail*)(p + num * sizeof(struct vring_desc));
+	vr->used = (void*)RTE_ALIGN_CEIL((uintptr_t)(&vr->avail->ring[num]), align);
+}
+
+static void virtio_legacy_setup_tx_queue(struct virtio_device* dev, uint16_t idx) {
+	if (idx != 1 && idx != 2) {
+		error("Can't setup queue %u as Tx queue", idx);
+	}
+
+	// Create virt queue itself - Section 4.1.5.1.3
+	write_io16(dev->fd, idx, VIRTIO_PCI_QUEUE_SEL);
+	uint32_t max_queue_size = read_io32(dev->fd, VIRTIO_PCI_QUEUE_NUM);
+	debug("Max queue size of tx queue #%u: %u", idx, max_queue_size);
+	if (max_queue_size == 0) {
+		return;
+	}
+	size_t virt_queue_mem_size = virtio_legacy_vring_size(max_queue_size, 4096);
+	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, true);
+	memset(mem.virt, 0xab, virt_queue_mem_size);
+	debug("Allocated %zu bytes for virt queue at %p", virt_queue_mem_size, mem.virt);
+	write_io32(dev->fd, mem.phy >> VIRTIO_PCI_QUEUE_ADDR_SHIFT, VIRTIO_PCI_QUEUE_PFN);
+
+	// Section 2.4.2 for layout
+	struct virtqueue* vq = calloc(1, sizeof(*vq) + sizeof(void*) * max_queue_size);
+	virtio_legacy_vring_init(&vq->vring, max_queue_size, mem.virt, 4096);
+	debug("vring desc: %p, vring avail: %p, vring used: %p", vq->vring.desc, vq->vring.avail, vq->vring.used);
+	for (size_t i = 0; i < vq->vring.num; ++i) {
+		vq->vring.desc[i].len = 0;
+		vq->vring.desc[i].addr = 0;
+		vq->vring.desc[i].flags = 0;
+		vq->vring.desc[i].next = 0;
+		vq->vring.avail->ring[i] = 0;
+		vq->vring.used->ring[i].id = 0;
+		vq->vring.used->ring[i].len = 0;
+	}
+	vq->vring.used->idx = 0;
+	vq->vring.avail->idx = 0;
+	vq->vq_used_last_idx = 0;
+
+	// Section 4.1.4.4
+	uint32_t notify_offset = read_io16(dev->fd, VIRTIO_PCI_QUEUE_NOTIFY);
+	debug("vq notifcation offset %u", notify_offset);
+	vq->notification_offset = notify_offset;
+
+	// Ctrl queue packets are not supplied by the user
+	if (idx == 2) {
+		vq->mempool = memory_allocate_mempool(max_queue_size, 2048);
+	}
+
+	// Disable interrupts - Section 2.4.7
+	vq->vring.avail->flags = VRING_AVAIL_F_NO_INTERRUPT;
+	vq->vring.used->flags = 0;
+
+	if (idx == 1) {
+		dev->tx_queue = vq;
+	} else {
+		dev->ctrl_queue = vq;
+	}
+}
+
+static void virtio_legacy_send_command(struct virtio_device* dev, void* cmd, size_t cmd_len) {
+	struct virtqueue* vq = dev->ctrl_queue;
+
+	if (cmd_len < sizeof(struct virtio_net_ctrl_hdr)) {
+		error("Command can not be shorter than control header");
+	}
+	if (((uint8_t*)cmd)[0] != VIRTIO_NET_CTRL_RX) {
+		error("Command class is not supported");
+	}
+
+	_mm_mfence();
+	// Find free desciptor slot
+	uint16_t idx = 0;
+	for (idx = 0; idx < vq->vring.num; ++idx) {
+		struct vring_desc* desc = &vq->vring.desc[idx];
+		if (desc->addr == 0) {
+			break;
+		}
+	}
+	if (idx == vq->vring.num) {
+		error("command queue full");
+	} else {
+		debug("Found free desc slot at %u (%u)", idx, vq->vring.num);
+	}
+
+	struct pkt_buf* buf = pkt_buf_alloc(vq->mempool);
+	if (!buf) {
+		error("Control queue ran out of buffers");
+	}
+	memcpy(buf->data, cmd, cmd_len);
+	vq->virtual_addresses[idx] = buf;
+
+	/* The following descriptor setup kills QEMU, but should be allowed with VIRTIO_F_ANY_LAYOUT
+	 * Error: kvm: virtio-net ctrl missing headers
+	 * Version: QEMU emulator version 2.7.1 pve-qemu-kvm_2.7.1-4
+	 */
+	// All in one descriptor
+	// vq->vring.desc[idx].len = cmd_len;
+	// vq->vring.desc[idx].addr = buf->buf_addr_phy + offsetof(struct pkt_buf, data);
+	// vq->vring.desc[idx].flags = VRING_DESC_F_WRITE;
+	// vq->vring.desc[idx].next = 0;
+
+	// Device-readable head: cmd header
+	vq->vring.desc[idx].len = 2;
+	vq->vring.desc[idx].addr = buf->buf_addr_phy + offsetof(struct pkt_buf, data);
+	vq->vring.desc[idx].flags = VRING_DESC_F_NEXT;
+	vq->vring.desc[idx].next = idx + 1;
+	// Device-readable payload: data
+	vq->vring.desc[idx + 1].len = cmd_len - 2 - 1; // Header and ack byte
+	vq->vring.desc[idx + 1].addr = buf->buf_addr_phy + offsetof(struct pkt_buf, data) + 2;
+	vq->vring.desc[idx + 1].flags = VRING_DESC_F_NEXT;
+	vq->vring.desc[idx + 1].next = idx + 2;
+	// Device-writable tail: ack flag
+	vq->vring.desc[idx + 2].len = 1;
+	vq->vring.desc[idx + 2].addr = buf->buf_addr_phy + offsetof(struct pkt_buf, data) + cmd_len - 1;
+	vq->vring.desc[idx + 2].flags = VRING_DESC_F_WRITE;
+	vq->vring.desc[idx + 2].next = 0;
+	vq->vring.avail->ring[vq->vring.avail->idx % vq->vring.num] = idx;
+	_mm_mfence();
+	vq->vring.avail->idx++;
+	_mm_mfence();
+
+	virtio_legacy_notify_queue(dev, 2);
+	_mm_mfence();
+
+	// Wait until the buffer got processed
+	while (vq->vq_used_last_idx == vq->vring.used->idx) {
+		_mm_mfence();
+		debug("Waiting...");
+		usleep(100000);
+	}
+	vq->vq_used_last_idx++;
+	// Check status and free buffer
+	struct vring_used_elem* e = &vq->vring.used->ring[vq->vring.used->idx];
+	debug("e %p: id %u len %u", e, e->id, e->len);
+	if (e->id != idx) {
+		error("Used buffer has different index as sent one");
+	}
+	if (vq->virtual_addresses[idx] != buf) {
+		error("buffer differ");
+	}
+	pkt_buf_free(buf);
+	vq->vring.desc[idx] = (struct vring_desc){};
+	vq->vring.desc[idx + 1] = (struct vring_desc){};
+	vq->vring.desc[idx + 2] = (struct vring_desc){};
+}
+
+static void virtio_legacy_set_promiscuous(struct virtio_device* dev, bool on) {
+	struct {
+		struct virtio_net_ctrl_hdr hdr;
+		uint8_t on;
+		uint8_t ack;
+	} __attribute__((__packed__)) cmd = {};
+	static_assert(sizeof(cmd) == 4, "Size of command struct wrong");
+
+	cmd.hdr.class = VIRTIO_NET_CTRL_RX;
+	cmd.hdr.cmd = VIRTIO_NET_CTRL_RX_PROMISC;
+	cmd.on = on ? 1 : 0;
+
+	virtio_legacy_send_command(dev, &cmd, sizeof(cmd));
+	info("Set promisc to %u", on);
+}
+
+void virtio_set_promisc(struct ixy_device* ixy, bool enabled) {
+	struct virtio_device* dev = IXY_TO_VIRTIO(ixy);
+	virtio_legacy_set_promiscuous(dev, enabled);
+}
+
+uint32_t virtio_get_link_speed(const struct ixy_device* dev) {
+	return 1000;
+}
+
+static const struct virtio_legacy_net_hdr net_hdr = {
+	.flags = 0,
+	.gso_type = VIRTIO_NET_HDR_GSO_NONE,
+	.hdr_len = 14 + 20 + 8,
+};
+
+static void virtio_legacy_setup_rx_queue(struct virtio_device* dev, uint16_t idx) {
+	if (idx != 0) {
+		error("Can't setup Tx queue as Rx");
+	}
+
+	// Create virt queue itself - Section 4.1.5.1.3
+	write_io16(dev->fd, idx, VIRTIO_PCI_QUEUE_SEL);
+	uint32_t max_queue_size = read_io32(dev->fd, VIRTIO_PCI_QUEUE_NUM);
+	debug("Max queue size of rx queue #%u: %u", idx, max_queue_size);
+	if (max_queue_size == 0) {
+		return;
+	}
+	uint32_t notify_offset = read_io16(dev->fd, VIRTIO_PCI_QUEUE_NOTIFY);
+	debug("Notifcation offset %u", notify_offset);
+	size_t virt_queue_mem_size = virtio_legacy_vring_size(max_queue_size, 4096);
+	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, true);
+	memset(mem.virt, 0xab, virt_queue_mem_size);
+	debug("Allocated %zu bytes for virt queue at %p", virt_queue_mem_size, mem.virt);
+	write_io32(dev->fd, mem.phy >> VIRTIO_PCI_QUEUE_ADDR_SHIFT, VIRTIO_PCI_QUEUE_PFN);
+
+	// Section 2.4.2 for layout
+	struct virtqueue* vq = calloc(1, sizeof(*vq) + sizeof(void*) * max_queue_size);
+	virtio_legacy_vring_init(&vq->vring, max_queue_size, mem.virt, 4096);
+	debug("vring desc: %p, vring avail: %p, vring used: %p", vq->vring.desc, vq->vring.avail, vq->vring.used);
+	for (size_t i = 0; i < vq->vring.num; ++i) {
+		vq->vring.desc[i].len = 0;
+		vq->vring.desc[i].addr = 0;
+		vq->vring.desc[i].flags = 0;
+		vq->vring.desc[i].next = 0;
+		vq->vring.avail->ring[i] = 0;
+		vq->vring.used->ring[i].id = 0;
+		vq->vring.used->ring[i].len = 0;
+	}
+	vq->vring.used->idx = 0;
+	vq->vring.avail->idx = 0;
+	vq->vq_used_last_idx = 0;
+
+	// Section 4.1.4.4
+	vq->notification_offset = notify_offset;
+
+	// Disable interrupts - Section 2.4.7
+	vq->vring.avail->flags = VRING_AVAIL_F_NO_INTERRUPT;
+	vq->vring.used->flags = 0;
+
+	// Allocate buffers and fill descriptor table - Section 3.2.1
+	// We allocate more bufs than what would fit in the queue,
+	// because we don't want to stall rx if users hold bufs for longer
+	vq->mempool = memory_allocate_mempool(max_queue_size * 4, 2048);
+
+	dev->rx_queue = vq;
+}
+
+static void virtio_legacy_init(struct virtio_device* dev) {
+	// Section 3.1
+	debug("Configuring bar0");
+	write_io8(dev->fd, VIRTIO_CONFIG_STATUS_RESET, VIRTIO_PCI_STATUS);
+	while (read_io8(dev->fd, VIRTIO_PCI_STATUS) != VIRTIO_CONFIG_STATUS_RESET) {
+		usleep(100);
+	}
+	write_io8(dev->fd, VIRTIO_CONFIG_STATUS_ACK, VIRTIO_PCI_STATUS);
+	write_io8(dev->fd, VIRTIO_CONFIG_STATUS_DRIVER, VIRTIO_PCI_STATUS);
+	// Negotiate features
+	uint32_t host_features = read_io32(dev->fd, VIRTIO_PCI_HOST_FEATURES);
+	debug("Host features: %x", host_features);
+	if (!(host_features & VIRTIO_F_VERSION_1)) {
+		error("In legacy mode but device is not legacy");
+	}
+	const uint32_t required_features = (1u << VIRTIO_NET_F_CSUM) | (1u << VIRTIO_NET_F_GUEST_CSUM) |
+					   (1u << VIRTIO_NET_F_CTRL_VQ) | (1u << VIRTIO_F_ANY_LAYOUT) |
+					   (1u << VIRTIO_NET_F_CTRL_RX) /*| (1u<<VIRTIO_NET_F_MQ)*/;
+	if ((host_features & required_features) != required_features) {
+		error("Device does not support required features");
+	}
+	debug("Guest features before negotiation: %x", read_io32(dev->fd, VIRTIO_PCI_GUEST_FEATURES));
+	write_io32(dev->fd, required_features, VIRTIO_PCI_GUEST_FEATURES);
+	debug("Guest features after negotiation: %x", read_io32(dev->fd, VIRTIO_PCI_GUEST_FEATURES));
+	// Queue setup - Section 5.1.2 for queue index calculation
+	// Legacy devices only have 3 queues
+	virtio_legacy_setup_rx_queue(dev, 0); // Rx
+	virtio_legacy_setup_tx_queue(dev, 1); // Tx
+	virtio_legacy_setup_tx_queue(dev, 2); // Control
+	_mm_mfence();
+	// Signal OK
+	write_io8(dev->fd, VIRTIO_CONFIG_STATUS_DRIVER_OK, VIRTIO_PCI_STATUS);
+	info("Setup complete");
+	// Recheck status
+	virtio_legacy_check_status(dev);
+	virtio_legacy_set_promiscuous(dev, true);
+}
+
+// read stat counters and accumulate in stats
+// stats may be NULL to just reset the counters
+void virtio_read_stats(struct ixy_device* ixy, struct device_stats* stats) {
+	struct virtio_device* dev = IXY_TO_VIRTIO(ixy);
+	if (stats) {
+		stats->rx_pkts += dev->rx_pkts;
+		stats->tx_pkts += dev->tx_pkts;
+		stats->rx_bytes += dev->rx_bytes;
+		stats->tx_bytes += dev->tx_bytes;
+	}
+	dev->rx_pkts = dev->tx_pkts = dev->rx_bytes = dev->tx_bytes = 0;
+}
+
+
+struct ixy_device* virtio_init(const char* pci_addr, uint16_t rx_queues, uint16_t tx_queues) {
+	if (getuid()) {
+		warn("Not running as root, this will probably fail");
+	}
+	if (rx_queues > 1) {
+		error("cannot configure %d rx queues: limit is %d", rx_queues, 1);
+	}
+	if (tx_queues > 1) {
+		error("cannot configure %d tx queues: limit is %d", tx_queues, 1);
+	}
+	remove_driver(pci_addr);
+	enable_dma(pci_addr);
+	struct virtio_device* dev = calloc(1, sizeof(*dev));
+	dev->ixy.pci_addr = strdup(pci_addr);
+	dev->ixy.driver_name = driver_name;
+	dev->ixy.num_rx_queues = rx_queues;
+	dev->ixy.num_tx_queues = tx_queues;
+	dev->ixy.rx_batch = virtio_rx_batch;
+	dev->ixy.tx_batch = virtio_tx_batch;
+	dev->ixy.read_stats = virtio_read_stats;
+	dev->ixy.set_promisc = virtio_set_promisc;
+	dev->ixy.get_link_speed = virtio_get_link_speed;
+	
+	int config = pci_open_resource(pci_addr, "config");
+	uint16_t device_id = read_io16(config, 2);
+	close(config);
+	// Check config if device is legacy network card
+	if (device_id == 0x1000) {
+		info("Detected virtio legacy network card");
+		dev->fd = pci_open_resource(pci_addr, "resource0");
+		virtio_legacy_init(dev);
+	} else {
+		error("Modern device not supported");
+	}
+	return &dev->ixy;
+}
+
+uint32_t virtio_rx_batch(struct ixy_device* ixy, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs) {
+	struct virtio_device* dev = IXY_TO_VIRTIO(ixy);
+	struct virtqueue* vq = dev->rx_queue;
+	uint32_t buf_idx;
+
+	_mm_mfence();
+	// Retrieve used bufs from the device
+	for (buf_idx = 0; buf_idx < num_bufs; ++buf_idx) {
+		// Section 3.2.2
+		if (vq->vq_used_last_idx == vq->vring.used->idx) {
+			break;
+		}
+		// info("Rx packet: last used %u, used idx %u", vq->vq_used_last_idx,
+		// vq->vring.used->idx);
+		struct vring_used_elem* e = vq->vring.used->ring + (vq->vq_used_last_idx % vq->vring.num);
+		// info("Used elem %p, id %u len %u", e, e->id, e->len);
+		struct vring_desc* desc = &vq->vring.desc[e->id];
+		vq->vq_used_last_idx++;
+		// We don't support chaining or indirect descriptors
+		if (desc->flags != VRING_DESC_F_WRITE) {
+			error("unsupported rx flags on descriptor: %x", desc->flags);
+		}
+		// info("Desc %lu %u %u %u", desc->addr, desc->len, desc->flags,
+		// desc->next);
+		*desc = (struct vring_desc){};
+
+		// Section 5.1.6.4
+		struct pkt_buf* buf = vq->virtual_addresses[e->id];
+		buf->size = e->len;
+		bufs[buf_idx] = buf;
+		//struct virtio_net_hdr* hdr = (void*)(buf->head_room + sizeof(buf->head_room) - sizeof(net_hdr));
+
+		// Update rx counter
+		dev->rx_bytes += buf->size;
+		dev->rx_pkts++;
+	}
+	// Fill empty slots in desciptor table
+	for (uint16_t idx = 0; idx < vq->vring.num; ++idx) {
+		struct vring_desc* desc = &vq->vring.desc[idx];
+		if (desc->addr != 0) { // descriptor points to something, therefore it is in use
+			continue;
+		}
+		// info("Found free desc slot at %u (%u)", idx, vq->vring.num);
+		struct pkt_buf* buf = pkt_buf_alloc(vq->mempool);
+		if (!buf) {
+			error("failed to allocate new mbuf for rx, you are either leaking memory or your mempool is too small");
+		}
+		buf->size = vq->mempool->buf_size;
+		memcpy(buf->head_room + sizeof(buf->head_room) - sizeof(net_hdr), &net_hdr, sizeof(net_hdr));
+		vq->vring.desc[idx].len = buf->size + sizeof(net_hdr);
+		vq->vring.desc[idx].addr =
+		    buf->buf_addr_phy + offsetof(struct pkt_buf, head_room) + sizeof(buf->head_room) - sizeof(net_hdr);
+		vq->vring.desc[idx].flags = VRING_DESC_F_WRITE;
+		vq->vring.desc[idx].next = 0;
+		vq->virtual_addresses[idx] = buf;
+		vq->vring.avail->ring[vq->vring.avail->idx % vq->vring.num] = idx;
+		_mm_mfence(); // Make sure exposed descriptors reach device before index is updated
+		vq->vring.avail->idx++;
+		_mm_mfence(); // Make sure the index update reaches device before it is triggered
+		virtio_legacy_notify_queue(dev, 0);
+	}
+	return buf_idx;
+}
+
+uint32_t virtio_tx_batch(struct ixy_device* ixy, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs) {
+	struct virtio_device* dev = IXY_TO_VIRTIO(ixy);
+	struct virtqueue* vq = dev->tx_queue;
+
+	_mm_mfence();
+	// Free sent buffers
+	while (vq->vq_used_last_idx != vq->vring.used->idx) {
+		// info("We can free some buffers: %u != %u", vq->vq_used_last_idx,
+		// vq->vring.used->idx);
+		struct vring_used_elem* e = vq->vring.used->ring + (vq->vq_used_last_idx % vq->vring.num);
+		// info("e %p, id %u", e, e->id);
+		struct vring_desc* desc = &vq->vring.desc[e->id];
+		desc->addr = 0;
+		desc->len = 0;
+		pkt_buf_free(vq->virtual_addresses[e->id]);
+		vq->vq_used_last_idx++;
+		_mm_mfence();
+	}
+	// Send buffers
+	uint32_t buf_idx;
+	uint16_t idx = 0; // Keep index of last found free descriptor and start searching from there
+	for (buf_idx = 0; buf_idx < num_bufs; ++buf_idx) {
+		struct pkt_buf* buf = bufs[buf_idx];
+		// Find free desc index
+		for (; idx < vq->vring.num; ++idx) {
+			struct vring_desc* desc = &vq->vring.desc[idx];
+			if (desc->addr == 0) {
+				break;
+			}
+		}
+		if (idx == vq->vring.num) {
+			break;
+		}
+		// info("Found free desc slot at %u (%u)", idx, vq->vring.num);
+
+		// Update tx counter
+		dev->tx_bytes += buf->size;
+		dev->tx_pkts++;
+
+		vq->virtual_addresses[idx] = buf;
+
+		// Copy header to headroom infront of data buffer
+		memcpy(buf->head_room + sizeof(buf->head_room) - sizeof(net_hdr), &net_hdr, sizeof(net_hdr));
+
+		vq->vring.desc[idx].len = buf->size + sizeof(net_hdr);
+		vq->vring.desc[idx].addr =
+		    buf->buf_addr_phy + offsetof(struct pkt_buf, head_room) + sizeof(buf->head_room) - sizeof(net_hdr);
+		vq->vring.desc[idx].flags = 0;
+		vq->vring.desc[idx].next = 0;
+		vq->vring.avail->ring[idx] = idx;
+	}
+	_mm_mfence();
+	vq->vring.avail->idx += buf_idx;
+	_mm_mfence();
+	virtio_legacy_notify_queue(dev, 1);
+	return buf_idx;
+}

--- a/src/driver/virtio.h
+++ b/src/driver/virtio.h
@@ -1,0 +1,29 @@
+#ifndef IXY_VIRTIO_H
+#define IXY_VIRTIO_H
+
+#include <stdbool.h>
+#include "stats.h"
+#include "memory.h"
+
+struct virtio_device {
+	struct ixy_device ixy;
+	int fd;
+	void* rx_queue;
+	void* tx_queue;
+	void* ctrl_queue;
+	uint64_t rx_pkts;
+	uint64_t tx_pkts;
+	uint64_t rx_bytes;
+	uint64_t tx_bytes;
+};
+
+#define IXY_TO_VIRTIO(ixy_device) container_of(ixy_device, struct virtio_device, ixy)
+
+struct ixy_device* virtio_init(const char* pci_addr, uint16_t rx_queues, uint16_t tx_queues);
+uint32_t virtio_get_link_speed(const struct ixy_device* dev);
+void virtio_set_promisc(struct ixy_device* dev, bool enabled);
+void virtio_read_stats(struct ixy_device* dev, struct device_stats* stats);
+uint32_t virtio_tx_batch(struct ixy_device* dev, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs);
+uint32_t virtio_rx_batch(struct ixy_device* dev, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs);
+
+#endif // IXY_VIRTIO_H

--- a/src/driver/virtio_type.h
+++ b/src/driver/virtio_type.h
@@ -1,0 +1,275 @@
+/*-
+ *   BSD LICENSE
+ *
+ *   Copyright(c) 2010-2014 Intel Corporation. All rights reserved.
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Intel Corporation nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _VIRTIO_RING_H_
+#define _VIRTIO_RING_H_
+
+#include <stdint.h>
+
+// #include <rte_common.h>
+#define RTE_PTR_ADD(ptr, x) ((void*)((uintptr_t)(ptr) + (x)))
+#define RTE_ALIGN_FLOOR(val, align) (typeof(val))((val) & (~((typeof(val))((align)-1))))
+#define RTE_ALIGN_CEIL(val, align) RTE_ALIGN_FLOOR(((val) + ((typeof(val))(align)-1)), align)
+#define RTE_PTR_ALIGN_FLOOR(ptr, align) ((typeof(ptr))RTE_ALIGN_FLOOR((uintptr_t)ptr, align))
+#define RTE_PTR_ALIGN_CEIL(ptr, align) RTE_PTR_ALIGN_FLOOR((typeof(ptr))RTE_PTR_ADD(ptr, (align)-1), align)
+
+/*
+ * VirtIO Header, located in BAR 0.
+ */
+#define VIRTIO_PCI_HOST_FEATURES 0  /* host's supported features (32bit, RO)*/
+#define VIRTIO_PCI_GUEST_FEATURES 4 /* guest's supported features (32, RW) */
+#define VIRTIO_PCI_QUEUE_PFN 8      /* physical address of VQ (32, RW) */
+#define VIRTIO_PCI_QUEUE_NUM 12     /* number of ring entries (16, RO) */
+#define VIRTIO_PCI_QUEUE_SEL 14     /* current VQ selection (16, RW) */
+#define VIRTIO_PCI_QUEUE_NOTIFY 16  /* notify host regarding VQ (16, RW) */
+#define VIRTIO_PCI_STATUS 18        /* device status register (8, RW) */
+#define VIRTIO_PCI_ISR 19           /* interrupt status register, reading also clears the register (8, RO) */
+/* Only if MSIX is enabled: */
+#define VIRTIO_MSI_CONFIG_VECTOR 20 /* configuration change vector (16, RW) */
+#define VIRTIO_MSI_QUEUE_VECTOR 22  /* vector for selected VQ notifications (16, RW) */
+
+/* Status byte for guest to report progress. */
+#define VIRTIO_CONFIG_STATUS_RESET 0x00
+#define VIRTIO_CONFIG_STATUS_ACK 0x01
+#define VIRTIO_CONFIG_STATUS_DRIVER 0x02
+#define VIRTIO_CONFIG_STATUS_DRIVER_OK 0x04
+#define VIRTIO_CONFIG_STATUS_FEATURES_OK 0x08
+#define VIRTIO_CONFIG_STATUS_FAILED 0x80
+
+/*
+ * How many bits to shift physical queue address written to QUEUE_PFN.
+ * 12 is historical, and due to x86 page size.
+ */
+#define VIRTIO_PCI_QUEUE_ADDR_SHIFT 12
+
+/* This marks a buffer as continuing via the next field. */
+#define VRING_DESC_F_NEXT 1
+/* This marks a buffer as write-only (otherwise read-only). */
+#define VRING_DESC_F_WRITE 2
+/* This means the buffer contains a list of buffer descriptors. */
+#define VRING_DESC_F_INDIRECT 4
+
+/* The feature bitmap for virtio net */
+#define VIRTIO_NET_F_CSUM 0            /* Host handles pkts w/ partial csum */
+#define VIRTIO_NET_F_GUEST_CSUM 1      /* Guest handles pkts w/ partial csum */
+#define VIRTIO_NET_F_MTU 3             /* Initial MTU advice. */
+#define VIRTIO_NET_F_MAC 5             /* Host has given MAC address. */
+#define VIRTIO_NET_F_GUEST_TSO4 7      /* Guest can handle TSOv4 in. */
+#define VIRTIO_NET_F_GUEST_TSO6 8      /* Guest can handle TSOv6 in. */
+#define VIRTIO_NET_F_GUEST_ECN 9       /* Guest can handle TSO[6] w/ ECN in. */
+#define VIRTIO_NET_F_GUEST_UFO 10      /* Guest can handle UFO in. */
+#define VIRTIO_NET_F_HOST_TSO4 11      /* Host can handle TSOv4 in. */
+#define VIRTIO_NET_F_HOST_TSO6 12      /* Host can handle TSOv6 in. */
+#define VIRTIO_NET_F_HOST_ECN 13       /* Host can handle TSO[6] w/ ECN in. */
+#define VIRTIO_NET_F_HOST_UFO 14       /* Host can handle UFO in. */
+#define VIRTIO_NET_F_MRG_RXBUF 15      /* Host can merge receive buffers. */
+#define VIRTIO_NET_F_STATUS 16         /* virtio_net_config.status available */
+#define VIRTIO_NET_F_CTRL_VQ 17        /* Control channel available */
+#define VIRTIO_NET_F_CTRL_RX 18        /* Control channel RX mode support */
+#define VIRTIO_NET_F_CTRL_VLAN 19      /* Control channel VLAN filtering */
+#define VIRTIO_NET_F_CTRL_RX_EXTRA 20  /* Extra RX mode control support */
+#define VIRTIO_NET_F_GUEST_ANNOUNCE 21 /* Guest can announce device on the network */
+#define VIRTIO_NET_F_MQ 22             /* Device supports Receive Flow Steering */
+#define VIRTIO_NET_F_CTRL_MAC_ADDR 23  /* Set MAC address */
+
+/* Do we get callbacks when the ring is completely used, even if we've suppressed them? */
+#define VIRTIO_F_NOTIFY_ON_EMPTY 24
+
+/* Can the device handle any descriptor layout? */
+#define VIRTIO_F_ANY_LAYOUT 27
+
+/* We support indirect buffer descriptors */
+#define VIRTIO_RING_F_INDIRECT_DESC 28
+
+#define VIRTIO_F_VERSION_1 32
+#define VIRTIO_F_IOMMU_PLATFORM 33
+
+/**
+ * Control the RX mode, ie. promiscuous, allmulti, etc...
+ * All commands require an "out" sg entry containing a 1 byte
+ * state value, zero = disable, non-zero = enable.  Commands
+ * 0 and 1 are supported with the VIRTIO_NET_F_CTRL_RX feature.
+ * Commands 2-5 are added with VIRTIO_NET_F_CTRL_RX_EXTRA.
+ */
+#define VIRTIO_NET_CTRL_RX 0
+#define VIRTIO_NET_CTRL_RX_PROMISC 0
+#define VIRTIO_NET_CTRL_RX_ALLMULTI 1
+#define VIRTIO_NET_CTRL_RX_ALLUNI 2
+#define VIRTIO_NET_CTRL_RX_NOMULTI 3
+#define VIRTIO_NET_CTRL_RX_NOUNI 4
+#define VIRTIO_NET_CTRL_RX_NOBCAST 5
+
+struct virtio_net_ctrl_hdr {
+	uint8_t class;
+	uint8_t cmd;
+} __attribute__((packed));
+
+typedef uint8_t virtio_net_ctrl_ack;
+
+#define VIRTIO_NET_OK 0
+#define VIRTIO_NET_ERR 1
+
+#define VIRTIO_MAX_CTRL_DATA 2048
+
+struct virtio_pmd_ctrl {
+	struct virtio_net_ctrl_hdr hdr;
+	virtio_net_ctrl_ack status;
+	uint8_t data[VIRTIO_MAX_CTRL_DATA];
+};
+
+/**
+ * This is the first element of the scatter-gather list.  If you don't
+ * specify GSO or CSUM features, you can simply ignore the header.
+ */
+struct virtio_legacy_net_hdr {
+#define VIRTIO_NET_HDR_F_NEEDS_CSUM 1 /**< Use csum_start,csum_offset*/
+#define VIRTIO_NET_HDR_F_DATA_VALID 2 /**< Checksum is valid */
+	uint8_t flags;
+#define VIRTIO_NET_HDR_GSO_NONE 0   /**< Not a GSO frame */
+#define VIRTIO_NET_HDR_GSO_TCPV4 1  /**< GSO frame, IPv4 TCP (TSO) */
+#define VIRTIO_NET_HDR_GSO_UDP 3    /**< GSO frame, IPv4 UDP (UFO) */
+#define VIRTIO_NET_HDR_GSO_TCPV6 4  /**< GSO frame, IPv6 TCP */
+#define VIRTIO_NET_HDR_GSO_ECN 0x80 /**< TCP has ECN set */
+	uint8_t gso_type;
+	uint16_t hdr_len;     /**< Ethernet + IP + tcp/udp hdrs */
+	uint16_t gso_size;    /**< Bytes to append to hdr_len per frame */
+	uint16_t csum_start;  /**< Position to start checksumming from */
+	uint16_t csum_offset; /**< Offset after that to place checksum */
+};
+
+/* This marks a buffer as continuing via the next field. */
+#define VRING_DESC_F_NEXT 1
+/* This marks a buffer as write-only (otherwise read-only). */
+#define VRING_DESC_F_WRITE 2
+/* This means the buffer contains a list of buffer descriptors. */
+#define VRING_DESC_F_INDIRECT 4
+
+/* The Host uses this in used->flags to advise the Guest: don't kick me
+ * when you add a buffer.  It's unreliable, so it's simply an
+ * optimization.  Guest will still kick if it's out of buffers. */
+#define VRING_USED_F_NO_NOTIFY 1
+/* The Guest uses this in avail->flags to advise the Host: don't
+ * interrupt me when you consume a buffer.  It's unreliable, so it's
+ * simply an optimization. */
+#define VRING_AVAIL_F_NO_INTERRUPT 1
+
+/* VirtIO ring descriptors: 16 bytes.
+ * These can chain together via "next". */
+struct vring_desc {
+	uint64_t addr;  /*  Address (guest-physical). */
+	uint32_t len;   /* Length. */
+	uint16_t flags; /* The flags as indicated above. */
+	uint16_t next;  /* We chain unused descriptors via this. */
+};
+
+struct vring_avail {
+	uint16_t flags;
+	uint16_t idx;
+	uint16_t ring[0];
+};
+
+/* id is a 16bit index. uint32_t is used here for ids for padding reasons. */
+struct vring_used_elem {
+	/* Index of start of used descriptor chain. */
+	uint32_t id;
+	/* Total length of the descriptor chain which was written to. */
+	uint32_t len;
+};
+
+struct vring_used {
+	uint16_t flags;
+	volatile uint16_t idx;
+	struct vring_used_elem ring[0];
+};
+
+struct vring {
+	unsigned int num;
+	struct vring_desc* desc;
+	struct vring_avail* avail;
+	struct vring_used* used;
+};
+
+/* The standard layout for the ring is a continuous chunk of memory which
+ * looks like this.  We assume num is a power of 2.
+ *
+ * struct vring {
+ *      // The actual descriptors (16 bytes each)
+ *      struct vring_desc desc[num];
+ *
+ *      // A ring of available descriptor heads with free-running index.
+ *      uint16_t avail_flags;
+ *      uint16_t avail_idx;
+ *      uint16_t available[num];
+ *      uint16_t used_event_idx;
+ *
+ *      // Padding to the next align boundary.
+ *      char pad[];
+ *
+ *      // A ring of used descriptor heads with free-running index.
+ *      uint16_t used_flags;
+ *      uint16_t used_idx;
+ *      struct vring_used_elem used[num];
+ *      uint16_t avail_event_idx;
+ * };
+ *
+ * NOTE: for VirtIO PCI, align is 4096.
+ */
+
+struct virtqueue {
+	struct vring vring; // The DMA'd region containing the descriptors etc.
+	// Additional information for the driver only
+	uint64_t notification_offset;
+	uint16_t vq_used_last_idx;
+	struct mempool* mempool; // Unused in Tx queues
+	// virtual addresses to map descriptors back to their mbuf for freeing
+	void* virtual_addresses[];
+};
+
+/*
+ * We publish the used event index at the end of the available ring, and vice
+ * versa. They are at the end for backwards compatibility.
+ */
+#define vring_used_event(vr) ((vr)->avail->ring[(vr)->num])
+#define vring_avail_event(vr) (*(uint16_t*)&(vr)->used->ring[(vr)->num])
+
+/*
+ * The following is used with VIRTIO_RING_F_EVENT_IDX.
+ * Assuming a given event_idx value from the other size, if we have
+ * just incremented index from old to new_idx, should we trigger an
+ * event?
+ */
+static inline int vring_need_event(uint16_t event_idx, uint16_t new_idx, uint16_t old) {
+	return (uint16_t)(new_idx - event_idx - 1) < (uint16_t)(new_idx - old);
+}
+
+#endif /* _VIRTIO_RING_H_ */

--- a/src/memory.h
+++ b/src/memory.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <stddef.h>
+#include <assert.h>
 
 #define HUGE_PAGE_BITS 21
 #define HUGE_PAGE_SIZE (1 << HUGE_PAGE_BITS)
@@ -14,8 +16,14 @@ struct pkt_buf {
 	struct mempool* mempool;
 	uint32_t mempool_idx;
 	uint32_t size;
+	uint8_t head_room[40];
 	uint8_t data[] __attribute__((aligned(64)));
 };
+
+static_assert(sizeof(struct pkt_buf) == 64, "pkt_buf too large");
+static_assert(offsetof(struct pkt_buf, data) == 64, "data at unexpected position");
+static_assert(offsetof(struct pkt_buf, data) - offsetof(struct pkt_buf, head_room) == 40, "head_room at unexpected position");
+static_assert(((struct pkt_buf*)(0))->head_room + 40 == ((struct pkt_buf*)(0))->data, "head_room at unexpected position");
 
 // everything here contains virtual addresses, the mapping to physical addresses are in the pkt_buf
 struct mempool {

--- a/src/pci.h
+++ b/src/pci.h
@@ -3,6 +3,9 @@
 
 #include <stdint.h>
 
+void remove_driver(const char* pci_addr);
+void enable_dma(const char* pci_addr);
 uint8_t* pci_map_resource(const char* bus_id);
+int pci_open_resource(const char* pci_addr, const char* resource);
 
-#endif //IXY_PCI_H
+#endif // IXY_PCI_H


### PR DESCRIPTION
Add automatic formating

Continue virtio driver

Fix virt queue physical address

Minimal rx

Implement queue notifications

Implement control queue command sending

Fix tx.
Use empty space in pkt_buf as head room.

Fix command sending.
Cleanup queue init.

Complete rx

Code cleanup

Minor formatting

Apply formating

Revert whitespace changes to unrelated files.
Apply formating to virtio driver files.