### PR TITLE
Add probabilistic brute force allocator for DMA blocks >2MiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_C_STANDARD 11)
 add_compile_options(-g -O2 -march=native -fomit-frame-pointer -std=c11
 	-D_XOPEN_SOURCE=700
 	-D_DEFAULT_SOURCE
+	-D_GNU_SOURCE
 	-Wall
 	-Wextra
 	-Wno-unused-parameter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,4 @@ set(SOURCE_COMMON src/pci.c src/memory.c src/stats.c src/driver/device.c src/dri
 
 add_executable(ixy-pktgen src/app/ixy-pktgen.c ${SOURCE_COMMON})
 add_executable(ixy-fwd src/app/ixy-fwd.c ${SOURCE_COMMON})
+add_executable(ixy-dma-allocate src/app/ixy-dma-allocate.c ${SOURCE_COMMON})

--- a/src/app/ixy-dma-allocate.c
+++ b/src/app/ixy-dma-allocate.c
@@ -3,9 +3,9 @@
 #include "memory.h"
 
 int main() {
-    memory_allocate_dma(4096, true);
-    memory_allocate_dma(4096 * 4, true);
-    memory_allocate_dma(4096 * 16, true);
-    memory_allocate_dma(4096 * 64, true);
-    memory_allocate_dma(4096 * 128, true);
+    memory_allocate_dma(4096, REQUIRE_CONTIGUOUS);
+    memory_allocate_dma(4096 * 4, REQUIRE_CONTIGUOUS);
+    memory_allocate_dma(4096 * 16, REQUIRE_CONTIGUOUS);
+    memory_allocate_dma(4096 * 64, REQUIRE_CONTIGUOUS);
+    memory_allocate_dma(4096 * 128, REQUIRE_CONTIGUOUS);
 }

--- a/src/app/ixy-dma-allocate.c
+++ b/src/app/ixy-dma-allocate.c
@@ -1,9 +1,10 @@
+#include <stdbool.h>
+
 #include "memory.h"
 
 int main() {
-    memory_allocate_dma(HUGE_PAGE_SIZE * 1, true);
-    memory_allocate_dma(HUGE_PAGE_SIZE * 2, true);
-    memory_allocate_dma(HUGE_PAGE_SIZE * 4, true);
-    memory_allocate_dma(HUGE_PAGE_SIZE * 8, true);
-    memory_allocate_dma(HUGE_PAGE_SIZE * 16, true);
+    memory_allocate_dma(4096, true);
+    memory_allocate_dma(4096 * 4, true);
+    memory_allocate_dma(4096 * 16, true);
+    memory_allocate_dma(4096 * 64, true);
 }

--- a/src/app/ixy-dma-allocate.c
+++ b/src/app/ixy-dma-allocate.c
@@ -7,4 +7,5 @@ int main() {
     memory_allocate_dma(4096 * 4, true);
     memory_allocate_dma(4096 * 16, true);
     memory_allocate_dma(4096 * 64, true);
+    memory_allocate_dma(4096 * 128, true);
 }

--- a/src/app/ixy-dma-allocate.c
+++ b/src/app/ixy-dma-allocate.c
@@ -1,0 +1,9 @@
+#include "memory.h"
+
+int main() {
+    memory_allocate_dma(HUGE_PAGE_SIZE * 1, true);
+    memory_allocate_dma(HUGE_PAGE_SIZE * 2, true);
+    memory_allocate_dma(HUGE_PAGE_SIZE * 4, true);
+    memory_allocate_dma(HUGE_PAGE_SIZE * 8, true);
+    memory_allocate_dma(HUGE_PAGE_SIZE * 16, true);
+}

--- a/src/driver/ixgbe.c
+++ b/src/driver/ixgbe.c
@@ -129,7 +129,7 @@ static void init_rx(struct ixgbe_device* dev) {
 		set_flags32(dev->addr, IXGBE_SRRCTL(i), IXGBE_SRRCTL_DROP_EN);
 		// setup descriptor ring, see section 7.1.9
 		uint32_t ring_size_bytes = NUM_RX_QUEUE_ENTRIES * sizeof(union ixgbe_adv_rx_desc);
-		struct dma_memory mem = memory_allocate_dma(ring_size_bytes, true);
+		struct dma_memory mem = memory_allocate_dma(ring_size_bytes, REQUIRE_CONTIGUOUS);
 		// neat trick from Snabb: initialize to 0xFF to prevent rogue memory accesses on premature DMA activation
 		memset(mem.virt, -1, ring_size_bytes);
 		set_reg32(dev->addr, IXGBE_RDBAL(i), (uint32_t) (mem.phy & 0xFFFFFFFFull));
@@ -180,7 +180,7 @@ static void init_tx(struct ixgbe_device* dev) {
 
 		// setup descriptor ring, see section 7.1.9
 		uint32_t ring_size_bytes = NUM_TX_QUEUE_ENTRIES * sizeof(union ixgbe_adv_tx_desc);
-		struct dma_memory mem = memory_allocate_dma(ring_size_bytes, true);
+		struct dma_memory mem = memory_allocate_dma(ring_size_bytes, REQUIRE_CONTIGUOUS);
 		memset(mem.virt, -1, ring_size_bytes);
 		set_reg32(dev->addr, IXGBE_TDBAL(i), (uint32_t) (mem.phy & 0xFFFFFFFFull));
 		set_reg32(dev->addr, IXGBE_TDBAH(i), (uint32_t) (mem.phy >> 32));

--- a/src/driver/virtio.c
+++ b/src/driver/virtio.c
@@ -56,7 +56,7 @@ static void virtio_legacy_setup_tx_queue(struct virtio_device* dev, uint16_t idx
 		return;
 	}
 	size_t virt_queue_mem_size = virtio_legacy_vring_size(max_queue_size, 4096);
-	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, true);
+	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, REQUIRE_CONTIGUOUS);
 	memset(mem.virt, 0xab, virt_queue_mem_size);
 	debug("Allocated %zu bytes for virt queue at %p", virt_queue_mem_size, mem.virt);
 	write_io32(dev->fd, mem.phy >> VIRTIO_PCI_QUEUE_ADDR_SHIFT, VIRTIO_PCI_QUEUE_PFN);
@@ -232,7 +232,7 @@ static void virtio_legacy_setup_rx_queue(struct virtio_device* dev, uint16_t idx
 	uint32_t notify_offset = read_io16(dev->fd, VIRTIO_PCI_QUEUE_NOTIFY);
 	debug("Notifcation offset %u", notify_offset);
 	size_t virt_queue_mem_size = virtio_legacy_vring_size(max_queue_size, 4096);
-	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, true);
+	struct dma_memory mem = memory_allocate_dma(virt_queue_mem_size, REQUIRE_CONTIGUOUS);
 	memset(mem.virt, 0xab, virt_queue_mem_size);
 	debug("Allocated %zu bytes for virt queue at %p", virt_queue_mem_size, mem.virt);
 	write_io32(dev->fd, mem.phy >> VIRTIO_PCI_QUEUE_ADDR_SHIFT, VIRTIO_PCI_QUEUE_PFN);

--- a/src/memory.c
+++ b/src/memory.c
@@ -54,7 +54,7 @@ static struct dma_memory memory_brute_force_allocate(size_t size) {
 
 	// Round up to next full page
 	if (size % page_size) {
-		size = (size - 1 + page_size) & ~page_size;
+		size = (size - 1 + page_size) & ~(page_size - 1);
 	}
 	debug("Requested %zu bytes, %zu pages", size, size / page_size);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -50,7 +50,7 @@ static bool is_phys_continuous(void* virt, size_t size) {
 
 static uint32_t huge_pg_id;
 
-static struct dma_memory memory_brute_force_allocate(size_t size, size_t page_size) {
+static struct dma_memory memory_brute_force_allocate(size_t size) {
 	const size_t num_pages = 32;
 	struct entry {
 		void* virt;
@@ -62,13 +62,14 @@ static struct dma_memory memory_brute_force_allocate(size_t size, size_t page_si
 	if (size % HUGE_PAGE_SIZE) {
 		size = ((size >> HUGE_PAGE_BITS) + 1) << HUGE_PAGE_BITS;
 	}
+	long page_size = sysconf(_SC_PAGESIZE);
+	// long page_size = HUGE_PAGE_SIZE;
 	// Allocate target area to map our pages into. This is to prevent collisions in the virtual address space during remapping
-	uint32_t id = __sync_fetch_and_add(&huge_pg_id, 1);
 	char path[PATH_MAX];
-	snprintf(path, PATH_MAX, "/mnt/huge/ixy-%d-%d", getpid(), id);
-	int fd = check_err(open(path, O_CREAT | O_RDWR, S_IRWXU), "open hugetlbfs file, check that /mnt/huge is mounted");
+	snprintf(path, PATH_MAX, "ixy-XXXXXX");
+	int fd = check_err(mkstemp(path), "open hugetlbfs file, check that /mnt/huge is mounted");
 	check_err(ftruncate(fd, (off_t) num_pages * page_size), "allocate huge page memory, check hugetlbfs configuration");
-	void* target = (void*) check_err(mmap(NULL, num_pages * page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0), "mmap hugepage");
+	void* target = (void*) check_err(mmap(NULL, num_pages * page_size, PROT_READ | PROT_WRITE, MAP_SHARED /*| MAP_HUGETLB*/, fd, 0), "mmap hugepage");
 	check_err(mlock(target, num_pages * page_size), "disable swap for DMA memory");
 	close(fd);
 	unlink(path);
@@ -76,22 +77,20 @@ static struct dma_memory memory_brute_force_allocate(size_t size, size_t page_si
 	((volatile uint8_t*) target)[0] = temp;
 	debug("Target area %p - %p", target, target + size);
 
-	// Allocate sample pages
-	for (size_t i = 0; i < num_pages; ++i) {
-		uint32_t id = __sync_fetch_and_add(&huge_pg_id, 1);
-		char path[PATH_MAX];
-		snprintf(path, PATH_MAX, "/mnt/huge/ixy-%d-%d", getpid(), id);
-		int fd = check_err(open(path, O_CREAT | O_RDWR, S_IRWXU), "open hugetlbfs file, check that /mnt/huge is mounted");
-		check_err(ftruncate(fd, (off_t) page_size), "allocate huge page memory, check hugetlbfs configuration");
-		void* virt_addr = (void*) check_err(mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0), "mmap hugepage");
-		check_err(mlock(virt_addr, page_size), "disable swap for DMA memory");
-		unlink(path);
-		volatile uint8_t temp = ((volatile uint8_t*) virt_addr)[0];
-		((volatile uint8_t*) virt_addr)[0] = temp;
 
+	// Allocate sample pages
+	snprintf(path, PATH_MAX, "ixy-XXXXXX");
+	fd = check_err(mkstemp(path), "open hugetlbfs file, check that /mnt/huge is mounted");
+	check_err(ftruncate(fd, (off_t) num_pages * page_size), "allocate huge page memory, check hugetlbfs configuration");
+	void* virt_addr = (void*) check_err(mmap(NULL, num_pages * page_size, PROT_READ | PROT_WRITE, MAP_SHARED /*| MAP_HUGETLB*/, fd, 0), "mmap hugepage");
+	check_err(mlock(virt_addr, page_size), "disable swap for DMA memory");
+	unlink(path);
+	for (size_t i = 0; i < num_pages; ++i) {	
+		temp = ((volatile uint8_t*) virt_addr + i * page_size)[0];
+		((volatile uint8_t*) virt_addr + i * page_size)[0] = temp;
 		pages[i].fd = fd;
-		pages[i].virt = virt_addr;
-		pages[i].phy = virt_to_phys(virt_addr);
+		pages[i].virt = virt_addr + i * page_size;
+		pages[i].phy = virt_to_phys(virt_addr + i * page_size);
 	}
 	// Sort by physical address
 	for (size_t i = 0; i < num_pages; ++i) {
@@ -108,7 +107,7 @@ static struct dma_memory memory_brute_force_allocate(size_t size, size_t page_si
 	}
 	// Map pages to target area
 	for (size_t i = 0; i < num_pages; ++i) {
-		pages[i].virt = (void*) check_err(mmap(target + i * page_size, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB | MAP_FIXED | MAP_LOCKED, pages[i].fd, 0), "remap page");
+		pages[i].virt = (void*) check_err(mmap(target + i * page_size, page_size, PROT_READ | PROT_WRITE, MAP_SHARED /*| MAP_HUGETLB*/ | MAP_FIXED | MAP_LOCKED, pages[i].fd, 0), "remap page");
 		close(pages[i].fd);
 	}
 	for (size_t i = 0; i < num_pages; ++i) {
@@ -141,7 +140,7 @@ struct dma_memory memory_allocate_dma(size_t size, bool require_contiguous) {
 		size = ((size >> HUGE_PAGE_BITS) + 1) << HUGE_PAGE_BITS;
 	}
 	if (require_contiguous && size > HUGE_PAGE_SIZE) {
-		return memory_brute_force_allocate(size, HUGE_PAGE_SIZE);
+		return memory_brute_force_allocate(size);
 		// this is the place to implement larger contiguous physical mappings if that's ever needed
 		error("could not map physically contiguous memory");
 	}

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include "memory.h"
 #include "log.h"
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -42,7 +42,11 @@ struct dma_memory {
 	uintptr_t phy;
 };
 
-struct dma_memory memory_allocate_dma(size_t size, bool require_contiguous);
+enum memory_dma_allocate_flags {
+	REQUIRE_CONTIGUOUS = 1 << 0,
+	USE_HUGEPAGES = 1 << 1,
+};
+struct dma_memory memory_allocate_dma(size_t size, enum memory_dma_allocate_flags flags);
 
 struct mempool* memory_allocate_mempool(uint32_t num_entries, uint32_t entry_size);
 uint32_t pkt_buf_alloc_batch(struct mempool* mempool, struct pkt_buf* bufs[], uint32_t num_bufs);


### PR DESCRIPTION
This PoC works as follows:
 1. Reserve target area to map into
 2. Allocate pool of 32 hugepages
 3. Order them by their physical addresses
 4. Remap them into the target area; this also unmaps the pages of it
 5. Check if we find a contiguous block of required size in the target area

This approach is not very *magical* to someone who understands paging, but still adds a fair amount of code (We could replace the existing dma_allocate function, as this implementation can of course also serve requests <2MiB).

In my initial tests it did not even fail once for allocations up to 16 pages (32MiB) on a system with 512 total pages.