### PR TITLE
fix use of multiple tx queues

### DIFF
--- a/src/driver/device.h
+++ b/src/driver/device.h
@@ -70,7 +70,7 @@ static inline uint32_t get_link_speed(const struct ixy_device* dev) {
 // calls ixy_tx_batch until all packets are queued with busy waiting
 static void ixy_tx_batch_busy_wait(struct ixy_device* dev, uint16_t queue_id, struct pkt_buf* bufs[], uint32_t num_bufs) {
 	uint32_t num_sent = 0;
-	while ((num_sent += ixy_tx_batch(dev, 0, bufs + num_sent, num_bufs - num_sent)) != num_bufs) {
+	while ((num_sent += ixy_tx_batch(dev, queue_id, bufs + num_sent, num_bufs - num_sent)) != num_bufs) {
 		// busy wait
 	}
 }


### PR DESCRIPTION
this fixes a small semantic error where we by default use queue 0, even if the input queue id is different