### PR TITLE
Close PCI resource file descriptor

### DIFF
--- a/src/pci.c
+++ b/src/pci.c
@@ -48,7 +48,9 @@ uint8_t* pci_map_resource(const char* pci_addr) {
 	int fd = check_err(open(path, O_RDWR), "open pci resource");
 	struct stat stat;
 	check_err(fstat(fd, &stat), "stat pci resource");
-	return (uint8_t*) check_err(mmap(NULL, stat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), "mmap pci resource");
+	uint8_t* hw = (uint8_t*) check_err(mmap(NULL, stat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), "mmap pci resource");
+	check_err(close(fd), "close pci resource");
+	return hw;
 }
 
 int pci_open_resource(const char* pci_addr, const char* resource, int flags) {


### PR DESCRIPTION
There shouldn't be any reason to keep this fd around; in fact it goes out of scope and gets leaked.

[I'm already doing this in ixy.ml](https://github.com/ixy-languages/ixy.ml/blob/master/lib/pCI.ml#L46) and it worked fine.