### PR TITLE
Support more numa nodes in setup-hugetlbfs.sh.

### DIFF
--- a/setup-hugetlbfs.sh
+++ b/setup-hugetlbfs.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 mkdir -p /mnt/huge
 (mount | grep /mnt/huge) > /dev/null || mount -t hugetlbfs hugetlbfs /mnt/huge
-for i in {0..7}
+for i in /sys/devices/system/node/node[0-9]*
 do
-	if [[ -e "/sys/devices/system/node/node$i" ]]
-	then
-		echo 512 > /sys/devices/system/node/node$i/hugepages/hugepages-2048kB/nr_hugepages
-	fi
+	echo 512 > "$i"/hugepages/hugepages-2048kB/nr_hugepages
 done


### PR DESCRIPTION
A simple change to support any number of numa nodes in setup-hugetlbfs.sh. The glob will expand to only what exists, so the `-e` test is no longer needed.

It is worth noting that the glob expansion will cause nr_hugepages to be set in filename sort order, not numa node numerical order; i.e. node10 will be set before node2, node100 will be set before node11, etc. I doubt this should matter, but wanted to bring it up just in case there was an assumption elsewhere in the code which relies on behavior caused by the set order.