### PR TITLE
Check vfio DMA allocation size before allocating

### DIFF
--- a/src/libixy-vfio.c
+++ b/src/libixy-vfio.c
@@ -18,11 +18,11 @@
 
 #include <driver/device.h>
 
+#include "libixy-vfio.h"
+
 #define IRQ_SET_BUF_LEN (sizeof(struct vfio_irq_set) + sizeof(int))
 #define MAX_INTERRUPT_VECTORS 32
 #define MSIX_IRQ_SET_BUF_LEN (sizeof(struct vfio_irq_set) + sizeof(int) * (MAX_INTERRUPT_VECTORS + 1))
-
-ssize_t MIN_DMA_MEMORY = 4096; // we can not allocate less than page_size memory
 
 void vfio_enable_dma(int device_fd) {
 	// write to the command register (offset 4) in the PCIe config space

--- a/src/libixy-vfio.h
+++ b/src/libixy-vfio.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#define MIN_DMA_MEMORY 4096 // we can not allocate less than page_size memory
+
 // enables DMA on a VFIO device
 void vfio_enable_dma(int device_fd);
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -45,6 +45,9 @@ struct dma_memory memory_allocate_dma(size_t size, bool require_contiguous) {
 	if (VFIO_CONTAINER_FILE_DESCRIPTOR != -1) {
 		// VFIO == -1 means that there is no VFIO container set, i.e. VFIO / IOMMU is not activated
 		debug("allocating dma memory via VFIO");
+		if (size < MIN_DMA_MEMORY) {
+			size = MIN_DMA_MEMORY;
+		}
 		void* virt_addr = (void*) check_err(mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB, -1, 0), "mmap hugepage");
 		// create IOMMU mapping
 		uint64_t iova = (uint64_t) vfio_map_dma(virt_addr, size);


### PR DESCRIPTION
The `size` parameter to `memory_allocate_dma()` that gets passed to `mmap()` could be less than `MIN_DMA_MEMORY`, yet `vfio_map_dma()` always maps at least `MIN_DMA_MEMORY`. This is currently not an issue because `MIN_DMA_MEMORY` is the size of a standard 4KiB page, but it might be larger in future.